### PR TITLE
Change added in place of example.com url in main page

### DIFF
--- a/index.md
+++ b/index.md
@@ -11,7 +11,7 @@ Lauren Alexander, Gabriel Goulet-Langlois, Joshua Wolff](http://cs109hubway.gith
 
 Learning from data in order to gain useful predictions and insights. This course introduces methods for five key facets of an investigation: data wrangling, cleaning, and sampling to get a suitable data set; data management to be able to access big data quickly and reliably; exploratory data analysis to generate hypotheses and intuition; prediction based on statistical methods such as regression and classification; and communication of results through visualization, stories, and interpretable summaries. 
 
-We will be using Python for all programming assignments and projects. All [lectures will be posted here](http://www.example.com/) and should be available 24 hours after meeting time.
+We will be using Python for all programming assignments and projects. All [lectures will be posted here](http://cs109.github.io/2015/pages/videos.html) and should be available 24 hours after meeting time.
 
 The course is also listed as AC209, STAT121, and E-109. 
 


### PR DESCRIPTION
A minor fix in main page of CS109 where lecture videos were pointing to "www.example.com" which should have rather pointed to "http://cs109.github.io/2015/pages/videos.html"
